### PR TITLE
E_CLASSROOM-118 [Integration] [Student] Password Reset

### DIFF
--- a/app/Http/Controllers/API/v1/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/API/v1/Auth/ForgotPasswordController.php
@@ -53,7 +53,7 @@ class ForgotPasswordController extends Controller
         if ($status === Password::PASSWORD_RESET) {
             return $this->authResponse('Password was reset successfully', 201);
         }
-        return $this->errorResponse("error", 422);
+        return $this->errorResponse(['message' => 'Incorrect Email'], 401);
     }
 
 

--- a/app/Http/Controllers/API/v1/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/API/v1/Auth/ForgotPasswordController.php
@@ -52,6 +52,6 @@ class ForgotPasswordController extends Controller
         if ($status === Password::PASSWORD_RESET) {
             return $this->authResponse('Password was reset successfully', 201);
         }
-        return $this->errorResponse(['message' => 'Incorrect Email'], 401);
+        return $this->errorResponse(['message' => 'Incorrect Email'], 422);
     }
 }

--- a/app/Http/Controllers/API/v1/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/API/v1/Auth/ForgotPasswordController.php
@@ -31,7 +31,6 @@ class ForgotPasswordController extends Controller
         throw ValidationException::withMessages([
             'email' => [trans($status)],
         ]);
-        
     }
 
     public function reset(ResetRequest $request)
@@ -55,6 +54,4 @@ class ForgotPasswordController extends Controller
         }
         return $this->errorResponse(['message' => 'Incorrect Email'], 401);
     }
-
-
 }

--- a/app/Http/Controllers/API/v1/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/API/v1/Auth/ForgotPasswordController.php
@@ -24,10 +24,14 @@ class ForgotPasswordController extends Controller
         if ($status == Password::RESET_LINK_SENT) {
             return $this->authResponse('The link was sent, please Check your email');
         }
+        else {
+            return $this->errorResponse("error", 422);
+        }
 
         throw ValidationException::withMessages([
             'email' => [trans($status)],
         ]);
+        
     }
 
     public function reset(ResetRequest $request)

--- a/app/Http/Controllers/API/v1/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/API/v1/Auth/ForgotPasswordController.php
@@ -25,7 +25,7 @@ class ForgotPasswordController extends Controller
             return $this->authResponse('The link was sent, please Check your email');
         }
         else {
-            return $this->errorResponse("error", 422);
+            return $this->errorResponse("Incorrect Email", 401);
         }
 
         throw ValidationException::withMessages([

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -82,7 +82,7 @@ class User extends Authenticatable
     
     public function sendPasswordResetNotification($token)
     {
-        $url = 'https://E-CLASSRROOOM/reset-password?token=' . $token;
+        $url = 'http://localhost:3003/new-password?token=' . $token;
         $this->notify(new ResetPasswordNotification($url));
     }
 }


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-118
### Definition of Done
- [x] Integrate password reset page with the backend.

### Commands to Run
N/A

### Notes
#### Main note
-  Create User link : http://localhost:3003/registration
-  I created FrontEnd repository link :  https://github.com/framgia/sph-classroom-els-fe/pull/22
#### Pages Affected
- http://localhost:3003/reset-password
set up your mailtrap
config your env file
- for mailtrap create account in mailtrap using this link : https://mailtrap.io/
- go to my inbox and click SMTP Settings
- click the dropdown menu cURL and choose  laravel 7+
- update your env file using the given credentials.

### Scenarios/ Test Cases
- [ ] Integrate password reset page with the backend.
#### User Interface
- [ ] N/A
#### User Experience 
- [ ] Can reset password
#### Functionality
- [ ] it should send token
- [ ] can resetPassword
### Screenshots

![image](https://user-images.githubusercontent.com/89382909/141062616-45403a3a-221a-4579-8135-bc764123daaf.png)

![image](https://user-images.githubusercontent.com/89382909/141062720-5a3f32d5-63d9-44f0-9121-a0c660cbf1bd.png)

![image](https://user-images.githubusercontent.com/89382909/141062737-a92365d0-490b-4be2-b78c-9fece7b8b7c2.png)


