### PR TITLE
E_CLASSROOM-136 [API] Quiz List Pagination

### DIFF
--- a/app/Http/Controllers/API/v1/Quiz/QuizController.php
+++ b/app/Http/Controllers/API/v1/Quiz/QuizController.php
@@ -19,7 +19,7 @@ class QuizController extends Controller
     {
         $quizzes = $category->quizzes;
 
-        return $this->showAll($quizzes);
+        return $this->paginatedList($quizzes);
     }
 
     /**

--- a/app/Http/Controllers/API/v1/Quiz/QuizController.php
+++ b/app/Http/Controllers/API/v1/Quiz/QuizController.php
@@ -6,9 +6,12 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Category;
 use App\Models\Quiz;
+use App\Traits\Pagination;
 
 class QuizController extends Controller
 {
+    use Pagination;
+    
     /**
      * Display a listing of all quizzes based on a.
      *
@@ -18,8 +21,8 @@ class QuizController extends Controller
     public function index(Category $category)
     {
         $quizzes = $category->quizzes;
-
-        return $this->paginatedList($quizzes);
+        
+        return $this->paginate($quizzes);
     }
 
     /**

--- a/app/Traits/Pagination.php
+++ b/app/Traits/Pagination.php
@@ -12,7 +12,7 @@ trait Pagination
     {
         $page = LengthAwarePaginator::resolveCurrentPage();
 
-        $perPage = 2;
+        $perPage = 12;
         if(request()->has('per_page')){
             $perPage = (int)request()->per_page;
         }

--- a/app/Traits/Pagination.php
+++ b/app/Traits/Pagination.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+trait Pagination
+{
+    protected function paginate(Collection $collection)
+    {
+        $page = LengthAwarePaginator::resolveCurrentPage();
+
+        $perPage = 2;
+        if(request()->has('per_page')){
+            $perPage = (int)request()->per_page;
+        }
+
+        $results = $collection->slice(($page-1) * $perPage, $perPage)->values();
+
+        $paginated = new LengthAwarePaginator($results, $collection->count(), $perPage, $page, [
+            'path' => LengthAwarePaginator::resolveCurrentPage()
+        ]);
+
+        $paginated->appends(request()->all());
+
+        return $paginated;
+    }
+}

--- a/app/Traits/ResponseMessage.php
+++ b/app/Traits/ResponseMessage.php
@@ -4,6 +4,8 @@ namespace App\Traits;
 
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 trait ResponseMessage
 {
@@ -30,5 +32,37 @@ trait ResponseMessage
     protected function authResponse($array = [], $code = 200)
     {
         return $this->successResponse($array, $code);
+    }
+    protected function paginatedList(Collection $collection, $code = 200)
+    {
+        $collection = $this->paginate($collection);
+
+        return $this->successResponse(['data' => $collection], $code);
+    }
+
+    protected function paginate(Collection $collection)
+    {
+        $rules = [
+            'per_page' => 'integer|min:2|max:50'
+        ];
+
+        Validator::validate(request()->all(), $rules);
+
+        $page = LengthAwarePaginator::resolveCurrentPage();
+
+        $perPage = 12;
+        if(request()->has('per_page')){
+            $perPage = (int)request()->per_page;
+        }
+
+        $results = $collection->slice(($page-1) * $perPage, $perPage)->values();
+
+        $paginated = new LengthAwarePaginator($results, $collection->count(), $perPage, $page, [
+            'path' => LengthAwarePaginator::resolveCurrentPage()
+        ]);
+
+        $paginated->appends(request()->all());
+
+        return $paginated;
     }
 }

--- a/app/Traits/ResponseMessage.php
+++ b/app/Traits/ResponseMessage.php
@@ -33,36 +33,4 @@ trait ResponseMessage
     {
         return $this->successResponse($array, $code);
     }
-    protected function paginatedList(Collection $collection, $code = 200)
-    {
-        $collection = $this->paginate($collection);
-
-        return $this->successResponse(['data' => $collection], $code);
-    }
-
-    protected function paginate(Collection $collection)
-    {
-        $rules = [
-            'per_page' => 'integer|min:2|max:50'
-        ];
-
-        Validator::validate(request()->all(), $rules);
-
-        $page = LengthAwarePaginator::resolveCurrentPage();
-
-        $perPage = 12;
-        if(request()->has('per_page')){
-            $perPage = (int)request()->per_page;
-        }
-
-        $results = $collection->slice(($page-1) * $perPage, $perPage)->values();
-
-        $paginated = new LengthAwarePaginator($results, $collection->count(), $perPage, $page, [
-            'path' => LengthAwarePaginator::resolveCurrentPage()
-        ]);
-
-        $paginated->appends(request()->all());
-
-        return $paginated;
-    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1fb3deb6403812df787412668146acf5",
+    "content-hash": "f411b247ad25832ba6ad94e770d09623",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-136

### Definition of Done
- [x] Create pagination functionality when retrieving list of quizzes based on category

### Commands to Run

### Notes
#### Main note
- http://localhost:82/api/v1/categories/1/quizzes?page=1
- You should get token to view the quizzes

#### Pages Affected
- N/A

#### Scenarios/ Test Cases
- [x] it should pagination functionality when retrieving list of quizzes based on category

### Screenshots
![pagination](https://user-images.githubusercontent.com/89514595/141403888-f0f7e8cb-2942-4880-960a-90abf53cd624.PNG)
![pagination1](https://user-images.githubusercontent.com/89514595/141403908-2800248a-e88c-4aa1-b9f0-7a5f7ef46c70.PNG)


