### PR TITLE
E_CLASSROOM-187 [BE] Student Detail Page Backend Functionality [3/4]

### DIFF
--- a/app/Http/Controllers/API/v1/Quiz/QuizzesTakenController.php
+++ b/app/Http/Controllers/API/v1/Quiz/QuizzesTakenController.php
@@ -7,6 +7,8 @@ use App\Http\Requests\Quiz\StoreQuizTakenRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use App\Http\Requests\Quiz\UpdateQuizTakenRequest;
+use Illuminate\Http\Request;
+use App\Models\Quiz;
 
 class QuizzesTakenController extends Controller
 {
@@ -68,5 +70,21 @@ class QuizzesTakenController extends Controller
             ->update(['score' => $request->score]);   
         
         return $this->successResponse(['score' => $request->score], 201);
+    }
+
+    /**
+     * Display a list of quizzes taken from other user.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function recent(Request $request)
+    {
+        $recent = Quiz::join('quizzes_taken', 'quizzes.id', '=',  'quizzes_taken.quiz_id')
+                        ->where('quizzes_taken.user_id', '=', $request->id)
+                        ->orderByDesc('quizzes_taken.created_at')
+                        ->limit(10)
+                        ->get();
+            
+        return $this->showAll($recent);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -48,5 +48,6 @@ Route::prefix('v1')->group(function () {
         Route::get('/students/{id}', [StudentController::class, 'show']);
         Route::post('/follow', [FollowController::class, 'follow']);
         Route::post('/unfollow', [FollowController::class, 'unfollow']);
+        Route::get('/recent-quizzes/{id}', [QuizzesTakenController::class, 'recent']);
     });
 });


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-187

### Definition of Done
- [x] User should be able to view specific student's most recent taken quizzes

### Commands to Run


### Notes
#### Main note
- 
#### Pages Affected
- http://localhost:82/api/v1/recent-quizzes/3

#### Scenarios/ Test Cases
- [ ] User should be able to view specific student's most recent taken quizzes
- [ ] Create functionality for retrieving specific student's most recent taken quizzes

### Screenshots
![DBrecentquiz](https://user-images.githubusercontent.com/89514595/144191484-6d42e4fe-dfde-4a46-b772-8bcd1f262c52.PNG)
![recentquiz](https://user-images.githubusercontent.com/89514595/144191503-8ed6274b-a1fd-4f24-894b-84ab834a9573.PNG)
![recentquiz1](https://user-images.githubusercontent.com/89514595/144191519-20577f79-6736-4d93-9dff-810e0efb2b2c.PNG)
![recentquiz2](https://user-images.githubusercontent.com/89514595/144191538-6172fba3-ae9b-4350-b120-ed7c664bff96.PNG)
![recentquiz3](https://user-images.githubusercontent.com/89514595/144191547-883a4a8c-3297-44f9-b9a0-fc6f402fc652.PNG)

