### PR TITLE
E_CLASSROOM-210 [BE] Category Filter Function

### DIFF
--- a/app/Http/Controllers/API/v1/Category/CategoryController.php
+++ b/app/Http/Controllers/API/v1/Category/CategoryController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\API\v1\Category;
 
+use App\Traits\CategoryFilter;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Category\StoreCategoryRequest;
 use App\Http\Requests\Category\UpdateCategoryRequest;
@@ -12,7 +13,7 @@ use App\Traits\Pagination;
 class CategoryController extends Controller
 {
 
-    use Pagination;
+    use Pagination, CategoryFilter;
 
     /**
      * Display a listing of Categories.
@@ -21,10 +22,15 @@ class CategoryController extends Controller
      */
     public function index()
     {
+        $query = request()->query();
         
         $categories = Category::withCount('subcategories');
 
-        $query = request()->query();
+        if(isset($query['filter'])){
+            $filtered_categories = $this->filter($query);
+
+            return $this->paginate($filtered_categories);
+        }
 
         if (request()->has('category_id')){
             $categories = $categories->where('category_id', request('category_id'));

--- a/app/Traits/CategoryFilter.php
+++ b/app/Traits/CategoryFilter.php
@@ -19,7 +19,9 @@ trait CategoryFilter
                                     ->pluck('category_id')
                                     ->all();
 
-            $taken_categories = Category::wherein('id', $taken_category)->get();
+            $taken_categories = Category::wherein('id', $taken_category)
+                                        ->whereNull('category_id')
+                                        ->get();
 
             return $taken_categories;
         } elseif ($query['filter'] === "not taken"){
@@ -29,7 +31,9 @@ trait CategoryFilter
                                         ->pluck('category_id')
                                         ->all();
 
-            $not_taken_categories = Category::whereNotIn('id', $not_taken_category)->get();
+            $not_taken_categories = Category::whereNotIn('id', $not_taken_category)
+                                            ->whereNull('category_id')
+                                            ->get();
 
             return $not_taken_categories;
         }

--- a/app/Traits/CategoryFilter.php
+++ b/app/Traits/CategoryFilter.php
@@ -12,7 +12,7 @@ trait CategoryFilter
 {
     protected function filter($query)
     {
-        if ($query['filter'] === "taken"){
+        if ($query['filter'] === "Taken"){
             $taken_category = Quiz::join('quizzes_taken', 'quizzes.id', '=', 'quizzes_taken.quiz_id')
                                     ->where('quizzes_taken.user_id', Auth::user()->id)
                                     ->get()
@@ -21,10 +21,11 @@ trait CategoryFilter
 
             $taken_categories = Category::wherein('id', $taken_category)
                                         ->whereNull('category_id')
+                                        ->orderBy('name', $query['sortBy'])
                                         ->get();
 
             return $taken_categories;
-        } elseif ($query['filter'] === "not taken"){
+        } elseif ($query['filter'] === "Not Taken"){
             $not_taken_category = Quiz::join('quizzes_taken', 'quizzes.id', '=', 'quizzes_taken.quiz_id')
                                         ->where('quizzes_taken.user_id', Auth::user()->id)
                                         ->get()
@@ -33,6 +34,7 @@ trait CategoryFilter
 
             $not_taken_categories = Category::whereNotIn('id', $not_taken_category)
                                             ->whereNull('category_id')
+                                            ->orderBy('name', $query['sortBy'])
                                             ->get();
 
             return $not_taken_categories;

--- a/app/Traits/CategoryFilter.php
+++ b/app/Traits/CategoryFilter.php
@@ -12,33 +12,22 @@ trait CategoryFilter
 {
     protected function filter($query)
     {
+        $taken_quizzes_id = Quiz::join('quizzes_taken', 'quizzes.id', '=', 'quizzes_taken.quiz_id')
+                            ->where('quizzes_taken.user_id', Auth::user()->id)
+                            ->get()
+                            ->pluck('category_id')
+                            ->all();
+
         if ($query['filter'] === "Taken"){
-            $taken_category = Quiz::join('quizzes_taken', 'quizzes.id', '=', 'quizzes_taken.quiz_id')
-                                    ->where('quizzes_taken.user_id', Auth::user()->id)
-                                    ->get()
-                                    ->pluck('category_id')
-                                    ->all();
-
-            $taken_categories = Category::wherein('id', $taken_category)
-                                        ->whereNull('category_id')
-                                        ->orderBy('name', $query['sortBy'])
-                                        ->get();
-
-            return $taken_categories;
+            $categories = Category::wherein('id', $taken_quizzes_id);
         } elseif ($query['filter'] === "Not Taken"){
-            $not_taken_category = Quiz::join('quizzes_taken', 'quizzes.id', '=', 'quizzes_taken.quiz_id')
-                                        ->where('quizzes_taken.user_id', Auth::user()->id)
-                                        ->get()
-                                        ->pluck('category_id')
-                                        ->all();
-
-            $not_taken_categories = Category::whereNotIn('id', $not_taken_category)
-                                            ->whereNull('category_id')
-                                            ->orderBy('name', $query['sortBy'])
-                                            ->get();
-
-            return $not_taken_categories;
+            $categories = Category::whereNotIn('id', $taken_quizzes_id);
         }
-    }
 
+        $categories = $categories->whereNull('category_id')
+                                 ->orderBy('name', $query['sortBy'])
+                                 ->get();
+
+        return $categories;
+    }
 }

--- a/app/Traits/CategoryFilter.php
+++ b/app/Traits/CategoryFilter.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Facades\Auth;
+use App\Models\Category;
+use Illuminate\Support\Facades\DB;
+use App\Models\Quiz;
+use App\Models\User;
+
+trait CategoryFilter
+{
+    protected function filter($query)
+    {
+        if ($query['filter'] === "taken"){
+            $taken_category = Quiz::join('quizzes_taken', 'quizzes.id', '=', 'quizzes_taken.quiz_id')
+                                    ->where('quizzes_taken.user_id', Auth::user()->id)
+                                    ->get()
+                                    ->pluck('category_id')
+                                    ->all();
+
+            $taken_categories = Category::wherein('id', $taken_category)->get();
+
+            return $taken_categories;
+        } elseif ($query['filter'] === "not taken"){
+            $not_taken_category = Quiz::join('quizzes_taken', 'quizzes.id', '=', 'quizzes_taken.quiz_id')
+                                        ->where('quizzes_taken.user_id', Auth::user()->id)
+                                        ->get()
+                                        ->pluck('category_id')
+                                        ->all();
+
+            $not_taken_categories = Category::whereNotIn('id', $not_taken_category)->get();
+
+            return $not_taken_categories;
+        }
+    }
+
+}


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-210

### Definition of Done
- [x] User will be able to filter categories by status (Taken, Not Taken)

### Commands to Run


### Notes
#### Main note
- Register more students accounts and try following some of those accounts to test the filter functionality
USE THIS QUERY PARAM TO FILTER

- Filter to only get taken category list.

http://localhost:82/api/v1/categories?filter=taken

- Filter to only get not taken category list.

http://localhost:82/api/v1/categories?filter=not taken

- In getting all lists of students excluding the logged-in student just simply remove the query params
#### Pages Affected
N/A

http://localhost:82/api/v1/categories

#### Scenarios/ Test Cases
- [ ] User will be able to filter categories by status (Taken, Not Taken)

### Screenshots
![taken](https://user-images.githubusercontent.com/89514595/149743073-34027a25-4a4a-4c3a-a2f9-49deb167134c.PNG)
![taken1](https://user-images.githubusercontent.com/89514595/149743083-cc7e8718-728d-45c1-a153-be6bfe83f89e.PNG)
![nottaken](https://user-images.githubusercontent.com/89514595/149743110-a4fdec4e-8370-4c15-b643-77b073aa3447.PNG)
![nottaken1](https://user-images.githubusercontent.com/89514595/149743119-29d46885-6c58-4d10-b8bc-5ee350361021.PNG)
![nottaken2](https://user-images.githubusercontent.com/89514595/149743132-80a24f7c-e32f-402c-bc7c-fd0501d34993.PNG)
![nottaken3](https://user-images.githubusercontent.com/89514595/149743150-160503b4-325e-4c82-b632-951adb0eb0a6.PNG)
![nottaken4](https://user-images.githubusercontent.com/89514595/149743166-715a7f49-967f-4709-a258-24d9da334c20.PNG)

