### PR TITLE
E_CLASSROOM-241 [Admin] BE Implement Admin Login

### DIFF
--- a/app/Http/Controllers/API/v1/Auth/AuthController.php
+++ b/app/Http/Controllers/API/v1/Auth/AuthController.php
@@ -18,11 +18,11 @@ class AuthController extends Controller
         $user = User::where('email', $request->email)->first();
 
         if($user && $user->user_type->user_type != $request->loginType){
-            return $this->errorResponse(['error' => 'Unauthorized'], 403);
+            return $this->errorResponse(['unauthorized' => trans('auth.unauthorized')], 403);
         }
 
         if (!$user || !Hash::check($request->password, $user->password)) {
-            return $this->errorResponse(['error' => !$user ? 'The email you’ve entered is incorrect.' : 'The password you’ve entered is incorrect.'], 401);           
+            return $this->errorResponse([ !$user ? 'email' : 'password' => !$user ? trans('auth.email') : trans('auth.password')], 401);           
         }
 
         $token = $user->user_type_id != ADMIN_TYPE_ID ? $user->createToken('access_token') : $user->createToken('access_token', ['admin']);

--- a/app/Http/Controllers/API/v1/Auth/AuthController.php
+++ b/app/Http/Controllers/API/v1/Auth/AuthController.php
@@ -13,22 +13,23 @@ class AuthController extends Controller
 {
     public function login(LoginRequest $request)
     {
+        define('ADMIN_TYPE_ID', 1);
+
         $user = User::where('email', $request->email)->first();
 
-        if (!$user || !Hash::check($request->password, $user->password)) {
-            if(!$user){
-                return $this->errorResponse(['error' => 'The email you’ve entered is incorrect.'], 401);
-            } else {
-                return $this->errorResponse(['error' => 'The password you’ve entered is incorrect.'], 401);
-            }
-           
+        if($user && $user->user_type->user_type != $request->loginType){
+            return $this->errorResponse(['error' => 'Unauthorized'], 403);
         }
 
-        $token = $user->createToken('access_token')->plainTextToken;
+        if (!$user || !Hash::check($request->password, $user->password)) {
+            return $this->errorResponse(['error' => !$user ? 'The email you’ve entered is incorrect.' : 'The password you’ve entered is incorrect.'], 401);           
+        }
+
+        $token = $user->user_type_id != ADMIN_TYPE_ID ? $user->createToken('access_token') : $user->createToken('access_token', ['admin']);
 
         $response = [
             'user' => $user,
-            'token' => $token
+            'token' => $token->plainTextToken
         ];
 
         return $this->authResponse($response);

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -14,7 +14,9 @@ return [
     */
 
     'failed' => 'These credentials do not match our records.',
+    'email' => 'The provided email is incorrect.',
     'password' => 'The provided password is incorrect.',
+    'unauthorized' => 'You are not authorized to access this page.',
     'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
 
 ];


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-241

### Definition of Done
- [x] Allow admin login
- [x] Provide seeders for admin

### Related PR

FE PR Link: https://github.com/framgia/sph-classroom-els-fe/pull/83

### Commands to Run
N/A

### Notes
#### Main note
- I did not create a seeder anymore since there is already an existing seeder for admin.
 > if you have already run the seeders command before, you should already have an admin account present in your local DB
to determine an Admin account it should have a user_type_id of `1`
#### Pages Affected
- N/A

#### Scenarios/ Test Cases

### Screenshots
