### PR TITLE
E_CLASSROOM-261 [FE/BE] Moving Subcategories Functionality

### DIFF
--- a/app/Http/Controllers/API/v1/Category/CategoryController.php
+++ b/app/Http/Controllers/API/v1/Category/CategoryController.php
@@ -97,4 +97,19 @@ class CategoryController extends Controller
 
         return $this->showOne($category);
     }
+
+    public function getCategories()
+    {
+        $query = request()->query();
+        
+        $categories = Category::withCount('subcategories');
+
+        if (request()->has('category_id')){
+            $categories = $categories->where('category_id', request('category_id'));
+        }else{
+            $categories = $categories->whereNull('category_id');
+        }
+
+        return $this->showAll($categories->get());
+    }
 }

--- a/app/Http/Requests/Quiz/StoreQuizRequest.php
+++ b/app/Http/Requests/Quiz/StoreQuizRequest.php
@@ -25,7 +25,7 @@ class StoreQuizRequest extends FormRequest
     {
         return [
             'instruction' => 'required|string',
-            'category_id' => 'required|string',
+            'category_id' => 'required',
             'title' => 'required|string', 
         ];
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -69,6 +69,6 @@ Route::prefix('v1')->group(function () {
         Route::post('/profileEdit', [ChangeNameEmailController::class, 'changeName']);
         Route::post('/profileEdituploadImage', [UploadImageController::class, 'uploadAvatar']);
         Route::post('/admin/add-category', [CategoryController::class, 'store']);
-        
+        Route::get('/admin/categories', [CategoryController::class, 'getCategories']);
     });
 });


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-261

### Definition of Done
- [x] Can get a list of categories without pagination
- [x] Should not get an error saying `categories_id should be a string` when adding a quiz when the category_id is an integer
### Related PR

FE Link: https://github.com/framgia/sph-classroom-els-fe/pull/110

### Commands to Run
N/A
### Notes
#### Main note
- N/A
#### Pages Affected
- N/A
### Screenshots
GETTING THE LIST OF CATEGORIES WITHOUT PAGINATION
![image](https://user-images.githubusercontent.com/91049234/155121665-39d33463-bbec-46f1-9e1a-bbe856c1fadf.png)

CAN ADD A QUIZ WITHOUT AN ERROR
![image](https://user-images.githubusercontent.com/91049234/155122072-7f5ca428-16af-419f-889a-6773156e72c5.png)

