### PR TITLE
E_CLASSROOM-275 [Bugfix] Category name cannot be edited and description misleading error message

### DIFF
--- a/app/Http/Requests/Category/StoreCategoryRequest.php
+++ b/app/Http/Requests/Category/StoreCategoryRequest.php
@@ -29,4 +29,13 @@ class StoreCategoryRequest extends FormRequest
             'image' => 'image'
         ];
     }
+
+    public function messages() 
+    {
+      return [
+        'name.unique' => 'Category Title is Taken. Please try again....',
+        'name.required' => 'The Title Field is Required. Please try again....',
+        'description.required' => 'The Description Field is Required. Please try again....',
+      ];
+    }
 }

--- a/app/Http/Requests/Category/UpdateCategoryRequest.php
+++ b/app/Http/Requests/Category/UpdateCategoryRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests\Category;
 use App\Models\Category;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class UpdateCategoryRequest extends FormRequest
 {
@@ -28,7 +29,10 @@ class UpdateCategoryRequest extends FormRequest
         $category = Category::where('name', $request->name)->first();
         
         return [
-            'name' => 'required|unique:categories,name,' . $category->id,
+            'name' => [
+                'required',
+                Rule::unique('categories','name')->ignore($category),
+            ],
             'description' => 'required',
             'image' => 'image'
         ];


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-275

### Definition of Done
- [x] Able to update Category title

### Commands to Run

### Related PR:
- https://github.com/framgia/sph-classroom-els-fe/pull/116
### Notes
#### Main note
to update a category

- http://localhost:82/api/v1/categories/:category_id
- Change HTTP method to PATCH
- use x-www-form-urlencoded when inputting data
  name:
  description:

#### Pages Affected
- N/A

#### Scenarios/ Test Cases
- N/A

### Screenshots
- N/A