### PR TITLE
E_CLASSROOM-283[FE/BE] Admin Invitation Acceptance

### DIFF
--- a/app/Http/Controllers/API/v1/Admin/AdminController.php
+++ b/app/Http/Controllers/API/v1/Admin/AdminController.php
@@ -8,7 +8,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use App\Notifications\InvitationToJoinAsAdmin;
 use App\Http\Requests\Admin\StoreAdminRequest;
-use App\Http\Requests\Admin\SetPasswordRequest;
+use App\Http\Requests\Admin\SetAdminPasswordRequest;
 
 class AdminController extends Controller
 {
@@ -31,5 +31,19 @@ class AdminController extends Controller
         ];
 
         return $this->authResponse($response, 201);
+    }
+
+    public function setNewPassword(SetAdminPasswordRequest $request)
+    {
+        $admin = User::where([['email', $request->email], ['user_type_id', 1]])->first();
+
+        if(!$admin) {
+            return $this->errorResponse(['error' => 'There is no admin account associated with this email.'], 422);
+        }
+
+        $admin->password = bcrypt($request->password);
+        $admin->save();
+
+        return $this->successResponse(['message' => 'Your new password has been successfully saved.'], 200);
     }
 }

--- a/app/Http/Requests/Admin/SetAdminPasswordRequest.php
+++ b/app/Http/Requests/Admin/SetAdminPasswordRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SetAdminPasswordRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'email' => 'required|email',
+            'password' => 'required|string|min:6',
+            'password_confirmation' => 'required|same:password',
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -39,6 +39,8 @@ Route::prefix('v1')->group(function () {
     Route::post('/forgot-password', [ForgotPasswordController::class, 'forgotPassword']);
     Route::post('/reset-password', [ForgotPasswordController::class, 'reset']);
 
+    Route::patch('/admin/set-password', [AdminController::class, 'setNewPassword']);
+
     // Authenticated routes
     Route::middleware(['auth:sanctum', 'api',])->group(function () {
         Route::post('/logout', [AuthController::class, 'logout']);


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-283

### Definition of Done
* [x] User can set their password
* [x] User can use their password after setting

### Notes
#### Main note
Try adding a new admin account before setting a new password, and try logging in once done to check whether it was successfully saved.

- Route to create a new admin user (name and email required): http://localhost:82/api/v1/admin/create 

- Route to Set New Admin Password: http://localhost:82/api/v1/admin/set-password

### Screenshots
![POSTMAN SET NEW PASSWORD](https://user-images.githubusercontent.com/91049234/156284145-c8e81a98-b740-4cdb-a343-13cc076d90de.gif)