### PR TITLE
E_CLASSROOM-288 (Dependent #296) [FE/BE] Quizzes Sort by Column

### DIFF
--- a/app/Http/Controllers/API/v1/Quiz/QuizController.php
+++ b/app/Http/Controllers/API/v1/Quiz/QuizController.php
@@ -10,10 +10,11 @@ use App\Traits\Pagination;
 use App\Models\Quiz;
 use App\Models\QuizTaken;
 use Illuminate\Http\Request;
+use App\Traits\QuizSort;
 
 class QuizController extends Controller
 {
-    use Pagination;
+    use Pagination, QuizSort;
     
     /**
      * Display a listing of all quizzes based on a.
@@ -66,12 +67,15 @@ class QuizController extends Controller
 
     public function adminQuiz(Request $request)
     {
-        $id = Auth::user()->id;
-        
-        $admin_quizzes = Category::join('quizzes', 'categories.id', '=', 'quizzes.category_id')
-                                ->get();
+        $query = request()->query();
 
-        return $this->paginate($admin_quizzes);
+        $quizzes = Category::join('quizzes', 'categories.id', '=', 'quizzes.category_id');
+
+        if(isset($query['sortDirection'])){
+            return $this->sort($query, $quizzes);
+        }
+
+        return $this->paginate($quizzes->get());
     }
 
     public function addQuiz(StoreQuizRequest $request)

--- a/app/Traits/QuizSort.php
+++ b/app/Traits/QuizSort.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Facades\Auth;
+use App\Models\Quiz;
+
+trait QuizSort
+{
+    protected function sort($query, $quizzes)
+    {
+        switch($query['sortBy']){
+            case 'Name': 
+                $sortBy = 'title';
+                break;
+            case 'Category':
+                $sortBy = 'name';
+                break;
+            default:
+                $sortBy = 'quizzes.'.strtolower($query['sortBy']);
+        }
+        
+        return $quizzes->orderBy($sortBy, $query['sortDirection'])->paginate(12);
+    }
+}


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-288

### Definition of Done
* [x] User should be able to sort by id, name, and category

### Related PR

FE Link: https://github.com/framgia/sph-classroom-els-fe/pull/125

### Notes
#### Main note
- Make sure to add these following query parameters when testing in Postman; 
> `sortBy` ---> can only accept these string values: Name, Category, and ID [The first letters should be capitalized, while the ID should be all caps]
> `sortDirection` ----> can only accept these string values: asc or desc [should be small letters]
> `page` ---> you can set this to 1 for the pagination

- For the list to go back to it's original order, just leave the sortBy and sortDirection blank, it still needs to be in the parameters but with no values.
### Screenshots
![QUIZZES SORT BY COLUMN POSTMAN](https://user-images.githubusercontent.com/91049234/156501570-29a7d5dc-e92b-4c11-9c25-7b4c7fefc85a.gif)