### PR TITLE
E_CLASSROOM-299 [FE/BE] [Admin] Change Password Page

### DIFF
--- a/app/Http/Controllers/API/v1/Admin/AdminController.php
+++ b/app/Http/Controllers/API/v1/Admin/AdminController.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Hash;
 use App\Notifications\InvitationToJoinAsAdmin;
 use App\Http\Requests\Admin\StoreAdminRequest;
 use App\Http\Requests\Admin\SetAdminPasswordRequest;
-use App\Http\Requests\Admin\updatePasswordRequest;
+use App\Http\Requests\Admin\UpdatePasswordRequest;
 
 class AdminController extends Controller
 {
@@ -49,7 +49,7 @@ class AdminController extends Controller
         return $this->successResponse(['message' => 'Your new password has been successfully saved.'], 200);
     }
 
-    public function updatePassword(updatePasswordRequest $request)
+    public function updatePassword(UpdatePasswordRequest $request)
     {
         $admin = Auth::user();
 

--- a/app/Http/Controllers/API/v1/Admin/AdminController.php
+++ b/app/Http/Controllers/API/v1/Admin/AdminController.php
@@ -6,9 +6,11 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
 use App\Notifications\InvitationToJoinAsAdmin;
 use App\Http\Requests\Admin\StoreAdminRequest;
 use App\Http\Requests\Admin\SetAdminPasswordRequest;
+use App\Http\Requests\Admin\updatePasswordRequest;
 
 class AdminController extends Controller
 {
@@ -45,5 +47,19 @@ class AdminController extends Controller
         $admin->save();
 
         return $this->successResponse(['message' => 'Your new password has been successfully saved.'], 200);
+    }
+
+    public function updatePassword(updatePasswordRequest $request)
+    {
+        $admin = Auth::user();
+
+        if(!Hash::check($request->password, $admin->password)){
+            return $this->errorResponse(['password' =>  trans('auth.password')], 401); 
+        }
+
+        $admin->password = bcrypt($request->new_password);
+        $admin->save();
+
+        return $this->successResponse(['message' => 'Your password has been successfully updated.'], 200);
     }
 }

--- a/app/Http/Requests/Admin/UpdatePasswordRequest.php
+++ b/app/Http/Requests/Admin/UpdatePasswordRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdatePasswordRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'password' => 'required|string|min:6',
+            'new_password' => 'required|string|min:6',
+            'password_confirmation' => 'required|same:new_password',
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -82,5 +82,6 @@ Route::prefix('v1')->group(function () {
         Route::post('/admin_edit_choices', [QuestionController::class, 'editChoices']);
         Route::get('/admin/nested-categories/{subcategory_id}', [CategoryController::class, 'getSubcategoryParentCategories']);
         Route::post('/admin/profile-edit', [ChangeNameEmailController::class, 'restore']);
+        Route::patch('/admin/password-edit', [AdminController::class, 'updatePassword']);
     });
 });


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-299

### Definition of Done
* [x] User can change password successfully
* [x] User should not be able to change their password if "Old Password" is incorrect
* [x] Validation should be present
* [x] Layout should be the same as the Figma design
* [x] After successful password update, redirect to profile view page

### Related PR

FE Link: https://github.com/framgia/sph-classroom-els-fe/pull/128

### Notes
#### Main note
- Try logging in again after updating the password to test whether password was successfully updated.

- To test in Postman, use this route: http://localhost:82/api/v1/admin/password-edit
  Required Fields: `password`, `new_password`, `password_confirmation`

### Screenshots
![EDIT PASSWORD POSTMAN](https://user-images.githubusercontent.com/91049234/156531459-a21ae5f1-2fbf-4ee2-9945-7e48f58ab6ce.gif)
