### PR TITLE
E_CLASSROOM-297 [Bugfix] Edit Category can have an identical title

### DIFF
--- a/app/Http/Requests/Category/UpdateCategoryRequest.php
+++ b/app/Http/Requests/Category/UpdateCategoryRequest.php
@@ -5,7 +5,6 @@ namespace App\Http\Requests\Category;
 use App\Models\Category;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Request;
-use Illuminate\Validation\Rule;
 
 class UpdateCategoryRequest extends FormRequest
 {
@@ -26,13 +25,9 @@ class UpdateCategoryRequest extends FormRequest
      */
     public function rules(Request $request)
     {
-        $category = Category::where('name', $request->name)->first();
-        
+
         return [
-            'name' => [
-                'required',
-                Rule::unique('categories','name')->ignore($category),
-            ],
+            'name' => "required|unique:categories,name,{$this->category->id}",
             'description' => 'required',
             'image' => 'image'
         ];

--- a/app/Http/Requests/Category/UpdateCategoryRequest.php
+++ b/app/Http/Requests/Category/UpdateCategoryRequest.php
@@ -36,7 +36,7 @@ class UpdateCategoryRequest extends FormRequest
     public function messages()
     {
         return [
-            'name.unique' => 'The Category Name has Already been Taken. Please try again....',
+            'name.unique' => 'The Name has Already been Taken. Please try again....',
         ];
     }
 }

--- a/app/Http/Requests/Category/UpdateCategoryRequest.php
+++ b/app/Http/Requests/Category/UpdateCategoryRequest.php
@@ -32,4 +32,11 @@ class UpdateCategoryRequest extends FormRequest
             'image' => 'image'
         ];
     }
+
+    public function messages()
+    {
+        return [
+            'name.unique' => 'The Category Name has Already been Taken. Please try again....',
+        ];
+    }
 }


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-297

### Definition of Done
- [x] Able to edit a  category 
- [x] Able to edit even there's is no changes

### Commands to Run

## Related PR
- https://github.com/framgia/sph-classroom-els-fe/pull/129
### Notes
#### Main note
you can test it directly on the app 
- http://localhost:82/api/v1/categories/{category_id}
PATCH in postman 
   name
   description
#### Pages Affected
- N/A

#### Scenarios/ Test Cases
- N/A

### Screenshots
![bugedit1](https://user-images.githubusercontent.com/89514595/156722614-fe1329b5-7f4a-4d53-a10e-9d41aac8e8f8.PNG)
![bugedit2](https://user-images.githubusercontent.com/89514595/156722625-6bca0ca3-cadd-4b6d-8ac6-fb30bd00c603.PNG)
![bugedit3](https://user-images.githubusercontent.com/89514595/156722637-abaf3ad9-389f-4f2e-8188-9b6a4a95304c.PNG)

