### PR TITLE
E_CLASSROOM-276 [FE/BE] Accounts List Page

### DIFF
--- a/app/Http/Controllers/API/v1/Admin/AdminController.php
+++ b/app/Http/Controllers/API/v1/Admin/AdminController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\API\v1\Admin;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\User;
+use App\Traits\Pagination;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use App\Notifications\InvitationToJoinAsAdmin;
@@ -14,6 +15,8 @@ use App\Http\Requests\Admin\UpdatePasswordRequest;
 
 class AdminController extends Controller
 {
+    use Pagination;
+
     public function store(StoreAdminRequest $request)
     {
         define('ADMIN_TYPE_ID', 1);
@@ -61,5 +64,14 @@ class AdminController extends Controller
         $admin->save();
 
         return $this->successResponse(['message' => 'Your password has been successfully updated.'], 200);
+    }
+
+    public function getAdminAccounts()
+    {
+        define('ADMIN_TYPE_ID', 1);
+
+        $admins = User::where('user_type_id', ADMIN_TYPE_ID)->get();
+
+        return $this->paginate($admins);
     }
 }

--- a/database/seeders/AdminSeeder.php
+++ b/database/seeders/AdminSeeder.php
@@ -17,12 +17,101 @@ class AdminSeeder extends Seeder
      */
     public function run()
     {
-        DB::table('users')->insert([
-            'name' => Str::random(10),
-            'email' => Str::random(10).'@gmail.com',
-            'password' => Hash::make('password'),
-            'user_type_id' => 1,
-            'avatar' => 'avatar.jpg'
-     ]);
+        $admins = [
+            [
+                'name' => 'John Doe',
+                'email' => 'admin@gmail.com',
+                'password' => bcrypt('password'),
+                'user_type_id' => 1,
+                'avatar' => 'avatar.jpg',
+                'created_at' => date("Y-m-d H:i:s")
+            ],[
+                'name' => 'Jane Doe',
+                'email' => 'janedoe@gmail.com',
+                'password' => bcrypt('password'),
+                'user_type_id' => 1,
+                'avatar' => 'avatar.jpg',
+                'created_at' => date("Y-m-d H:i:s")
+            ],[
+                'name' => 'Calvin Harris',
+                'email' => 'calvin@gmail.com',
+                'password' => bcrypt('password'),
+                'user_type_id' => 1,
+                'avatar' => 'avatar.jpg',
+                'created_at' => date("Y-m-d H:i:s")
+            ],[
+                'name' => 'Bruce Wayne',
+                'email' => 'bruce@gmail.com',
+                'password' => bcrypt('password'),
+                'user_type_id' => 1,
+                'avatar' => 'avatar.jpg',
+                'created_at' => date("Y-m-d H:i:s")
+            ],[
+                'name' => 'Tony Stark',
+                'email' => 'tonystark@gmail.com',
+                'password' => bcrypt('password'),
+                'user_type_id' => 1,
+                'avatar' => 'avatar.jpg',
+                'created_at' => date("Y-m-d H:i:s")
+            ],[
+                'name' => 'Mark Zuckerberg',
+                'email' => 'markz@gmail.com',
+                'password' => bcrypt('password'),
+                'user_type_id' => 1,
+                'avatar' => 'avatar.jpg',
+                'created_at' => date("Y-m-d H:i:s")
+            ],[
+                'name' => 'Charles Babbage',
+                'email' => 'charles@gmail.com',
+                'password' => bcrypt('password'),
+                'user_type_id' => 1,
+                'avatar' => 'avatar.jpg',
+                'created_at' => date("Y-m-d H:i:s")
+            ],[
+                'name' => 'Dennis Ritchie',
+                'email' => 'dennis@gmail.com',
+                'password' => bcrypt('password'),
+                'user_type_id' => 1,
+                'avatar' => 'avatar.jpg',
+                'created_at' => date("Y-m-d H:i:s")
+            ],[
+                'name' => 'Jon Bellion',
+                'email' => 'jon@gmail.com',
+                'password' => bcrypt('password'),
+                'user_type_id' => 1,
+                'avatar' => 'avatar.jpg',
+                'created_at' => date("Y-m-d H:i:s")
+            ],[
+                'name' => 'Ryan Reynolds',
+                'email' => 'ryanreynolds@gmail.com',
+                'password' => bcrypt('password'),
+                'user_type_id' => 1,
+                'avatar' => 'avatar.jpg',
+                'created_at' => date("Y-m-d H:i:s")
+            ],[
+                'name' => 'Peter Parker',
+                'email' => 'peterparker@gmail.com',
+                'password' => bcrypt('password'),
+                'user_type_id' => 1,
+                'avatar' => 'avatar.jpg',
+                'created_at' => date("Y-m-d H:i:s")
+            ],[
+                'name' => 'Stephen Strange',
+                'email' => 'strange@gmail.com@gmail.com',
+                'password' => bcrypt('password'),
+                'user_type_id' => 1,
+                'avatar' => 'avatar.jpg',
+                'created_at' => date("Y-m-d H:i:s")
+            ],[
+                'name' => 'Diana Prince',
+                'email' => 'dianaprince@gmail.com@gmail.com',
+                'password' => bcrypt('password'),
+                'user_type_id' => 1,
+                'avatar' => 'avatar.jpg',
+                'created_at' => date("Y-m-d H:i:s")
+            ]
+        ];
+        
+        DB::table('users')->insert($admins);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -83,5 +83,6 @@ Route::prefix('v1')->group(function () {
         Route::get('/admin/nested-categories/{subcategory_id}', [CategoryController::class, 'getSubcategoryParentCategories']);
         Route::post('/admin/profile-edit', [ChangeNameEmailController::class, 'restore']);
         Route::patch('/admin/password-edit', [AdminController::class, 'updatePassword']);
+        Route::get('/admin/admins', [AdminController::class, 'getAdminAccounts']);
     });
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -83,6 +83,6 @@ Route::prefix('v1')->group(function () {
         Route::get('/admin/nested-categories/{subcategory_id}', [CategoryController::class, 'getSubcategoryParentCategories']);
         Route::post('/admin/profile-edit', [ChangeNameEmailController::class, 'restore']);
         Route::patch('/admin/password-edit', [AdminController::class, 'updatePassword']);
-        Route::get('/admin/admins', [AdminController::class, 'getAdminAccounts']);
+        Route::get('/admin/users', [AdminController::class, 'getAdminAccounts']);
     });
 });


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-276

### Definition of Done
- [x] Get all admin accounts
- [x] Pagination is working
- [x] Seeder command is working

### Related PR

FE Link: https://github.com/framgia/sph-classroom-els-fe/pull/130

### Commands to Run

- Execute the Admin Seeders, to add more admin users before checking.

```
docker-compose exec backend php artisan db:seed --class=AdminSeeder
```

### Notes
#### Main note
- API Route to get the list of admin accounts:  http://localhost:82/api/v1/admin/users
- Add `page` as key and input `2` for its value under the Params tab in Postman, to test pagination.

_refer to the screenshot below_

### Screenshots
> ![image](https://user-images.githubusercontent.com/91049234/156983055-00a5035b-8ce4-4c84-a7cf-33c813bfc4ec.png)

