### PR TITLE
E_CLASSROOM-286 (Dependent #288) [FE/BE] Categories sort by column

### DIFF
--- a/app/Http/Controllers/API/v1/Category/CategoryController.php
+++ b/app/Http/Controllers/API/v1/Category/CategoryController.php
@@ -9,11 +9,12 @@ use App\Http\Requests\Category\UpdateCategoryRequest;
 use Illuminate\Http\Request;
 use App\Models\Category;
 use App\Traits\Pagination;
+use App\Traits\SortCategories;
 
 class CategoryController extends Controller
 {
 
-    use Pagination, CategoryFilter;
+    use Pagination, CategoryFilter, SortCategories;
 
     /**
      * Display a listing of Categories.
@@ -134,5 +135,18 @@ class CategoryController extends Controller
                 self::addParentCategory($categories, $parentCategory);
             }
         }
+    }
+
+    public function listOfCategories(Request $request)
+    {
+        $query = request()->query();
+
+        $categories = Category::withCount('subcategories');
+
+        if(isset($query['sortDirection'])){
+            return $this->sort($query, $categories);
+        }
+
+        return $this->paginate($categories->get());
     }
 }

--- a/app/Traits/SortCategories.php
+++ b/app/Traits/SortCategories.php
@@ -9,14 +9,6 @@ trait SortCategories
 {
     protected function sort($query, $categories)
     {
-        switch($query['sortBy']){
-            case 'Name': 
-                $sortBy = strtolower($query['sortBy']);
-                break;
-            default:
-                $sortBy = 'categories.'.strtolower($query['sortBy']);
-        }
-        
-        return $categories->orderBy($sortBy, $query['sortDirection'])->paginate(12);
+        return $categories->orderBy(strtolower($query['sortBy']), $query['sortDirection'])->paginate(12);
     }
 }

--- a/app/Traits/SortCategories.php
+++ b/app/Traits/SortCategories.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Facades\Auth;
+use App\Models\Category;
+
+trait SortCategories
+{
+    protected function sort($query, $categories)
+    {
+        switch($query['sortBy']){
+            case 'Name': 
+                $sortBy = strtolower($query['sortBy']);
+                break;
+            default:
+                $sortBy = 'categories.'.strtolower($query['sortBy']);
+        }
+        
+        return $categories->orderBy($sortBy, $query['sortDirection'])->paginate(12);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -75,7 +75,7 @@ Route::prefix('v1')->group(function () {
         Route::get('/admin_quizzes', [QuizController::class, 'adminQuiz']);
         Route::post('/admin/add-quiz', [QuizController::class, 'addQuiz']);
         Route::post('/admin/add-category', [CategoryController::class, 'store']);
-        Route::get('/admin/categories', [CategoryController::class, 'getCategories']);
+        Route::get('/admin/categories-data', [CategoryController::class, 'getCategories']);
         Route::post('/admin_add_question', [QuestionController::class, 'addQuestion']);
         Route::post('/admin_add_choices', [QuestionController::class, 'addChoices']);
         Route::post('/admin_edit_question', [QuestionController::class, 'editQuestion']);
@@ -84,5 +84,6 @@ Route::prefix('v1')->group(function () {
         Route::post('/admin/profile-edit', [ChangeNameEmailController::class, 'restore']);
         Route::patch('/admin/password-edit', [AdminController::class, 'updatePassword']);
         Route::get('/admin/users', [AdminController::class, 'getAdminAccounts']);
+        Route::get('/admin/categories', [CategoryController::class, 'listOfCategories']);
     });
 });


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-286

### Definition of Done
- [x] User should be able to sort by id or name

### Commands to Run

## Related PR:
- https://github.com/framgia/sph-classroom-els-fe/pull/131
### Notes
#### Main note
- http://localhost:82/api/v1/admin/categories-data
- Make sure to add these following query parameters when testing in Postman;
> sortBy ---> can only accept these string values: Name, Category, and ID [The first letters should be capitalized, while the ID should be all caps]
> sortDirection ----> can only accept these string values: asc or desc [should be small letters]
> page ---> you can set this to 1 for the pagination
- For the list to go back to it's original order, just leave the sortBy and sortDirection blank, it still needs to be in the parameters but with no values.

#### Pages Affected
- N/A

#### Scenarios/ Test Cases
- [x] it should sort by id or name

### Screenshots
![categoryadmin1](https://user-images.githubusercontent.com/89514595/157000530-0ea75dde-51b8-47c0-aa12-1606c26d68a9.gif)

