### PR TITLE
E_CLASSROOM-295 [Admin] [FE/BE] Admin User search by name or email

### DIFF
--- a/app/Http/Controllers/API/v1/Admin/AdminController.php
+++ b/app/Http/Controllers/API/v1/Admin/AdminController.php
@@ -68,10 +68,15 @@ class AdminController extends Controller
 
     public function getAdminAccounts()
     {
-        define('ADMIN_TYPE_ID', 1);
+            $id = Auth::user()->id;
 
-        $admins = User::where('user_type_id', ADMIN_TYPE_ID)->get();
+            $query = request()->query();
 
-        return $this->paginate($admins);
+            $admins = User::searchAndExcludeLoggedInUserAndStudents($id, $query['search'])
+                            ->where('id', '!=', $id)
+                            ->where('user_type_id', 1)
+                            ->get();
+
+            return $this->paginate($admins);
     }
 }

--- a/app/Http/Controllers/API/v1/Admin/AdminController.php
+++ b/app/Http/Controllers/API/v1/Admin/AdminController.php
@@ -68,15 +68,15 @@ class AdminController extends Controller
 
     public function getAdminAccounts()
     {
-            $id = Auth::user()->id;
+        $id = Auth::user()->id;
 
-            $query = request()->query();
+        $query = request()->query();
 
-            $admins = User::searchAndExcludeLoggedInUserAndStudents($id, $query['search'])
-                            ->where('id', '!=', $id)
-                            ->where('user_type_id', 1)
-                            ->get();
+        $admins = User::searchOtherAdminAccounts($id, $query['search'])
+                        ->where('id', '!=', $id)
+                        ->where('user_type_id', 1)
+                        ->get();
 
-            return $this->paginate($admins);
+        return $this->paginate($admins);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -96,7 +96,7 @@ class User extends Authenticatable
                      ->where('user_type_id', 2);
     }
 
-    public function scopeSearchAndExcludeLoggedInUserAndStudents($query, $id, $search)
+    public function scopeSearchOtherAdminAccounts($query, $id, $search)
     {
         return $query->where('name', 'LIKE', '%' . $search . '%')
                      ->orWhere('email', 'LIKE', '%' . $search . '%');

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -95,4 +95,10 @@ class User extends Authenticatable
                      ->where('name', 'LIKE', '%' . $search . '%')
                      ->where('user_type_id', 2);
     }
+
+    public function scopeSearchAndExcludeLoggedInUserAndStudents($query, $id, $search)
+    {
+        return $query->where('name', 'LIKE', '%' . $search . '%')
+                     ->orWhere('email', 'LIKE', '%' . $search . '%');
+    }
 }


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-295

### Definition of Done
- [x] Able to search by name or email

### Commands to Run

## Related PR:
- 
### Notes
#### Main note
- http://localhost:82/api/v1/admin/users
Make sure to add these following query parameters when testing in Postman;
> search -> can only accept these string values: name or email.

#### Pages Affected
- N/A

#### Scenarios/ Test Cases
- N/A

### Screenshots
Name:
![adminsearch](https://user-images.githubusercontent.com/89514595/157412481-9af3e937-2765-432a-8845-f862e53c1957.PNG)
Email:
![adminsearch1](https://user-images.githubusercontent.com/89514595/157412493-895c4155-f302-4f1f-bead-4630f8f60d82.PNG)


