### PR TITLE
E_CLASSROOM-280 [FE/BE] Sort admin table by column

### DIFF
--- a/app/Http/Controllers/API/v1/Admin/AdminController.php
+++ b/app/Http/Controllers/API/v1/Admin/AdminController.php
@@ -74,9 +74,12 @@ class AdminController extends Controller
 
         $admins = User::searchOtherAdminAccounts($id, $query['search'])
                         ->where('id', '!=', $id)
-                        ->where('user_type_id', 1)
-                        ->get();
+                        ->where('user_type_id', 1);
 
-        return $this->paginate($admins);
+        if(isset($query['sortDirection'])){
+            return $admins->orderBy($query['sortBy'], strtolower($query['sortDirection']))->paginate(12);
+        }
+
+        return $this->paginate($admins->get());
     }
 }


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-280

### Definition of Done
* [x] User should be able to sort by id, name, and email

### Related PR

FE Link: https://github.com/framgia/sph-classroom-els-fe/pull/139

### Notes
#### Main note
- API url: http://localhost:82/api/v1/admin/users

- Make sure to add these following query parameters when testing in Postman; 
> `sortBy` ---> can only accept these string values: Name, Category, and ID [The first letters should be capitalized, while the ID should be all caps]
> `sortDirection` ----> can only accept these string values: asc or desc [should be small letters]
> `search` ---> can be left blank
> `page` ---> you can set this to 1 for the pagination or can be left blank as well

- For the list to go back to its original order, just leave the sortBy and sortDirection blank, it still needs to be in the parameters but with no values.

_refer to below screenrecord_

### Screenshots
> ![admin sort by col postman](https://user-images.githubusercontent.com/91049234/157577383-efabd23b-49a4-4594-9da7-9147eff8d5cb.gif)
