### PR TITLE
E_CLASSROOM-301 [FE/BE] [Admin] Filtering quizzes by name and category

### DIFF
--- a/app/Http/Controllers/API/v1/Category/CategoryController.php
+++ b/app/Http/Controllers/API/v1/Category/CategoryController.php
@@ -147,13 +147,10 @@ class CategoryController extends Controller
             return $this->sort($query, $categories);
         }
 
+        if($query['listCondition'] === 'unpaginated'){
+            return $this->showAll($categories->get());
+        }
+
         return $this->paginate($categories->get());
-    }
-
-    public function getUnpaginatedCategoryList() 
-    {
-        $categories = Category::all();
-
-        return $this->showAll($categories);
     }
 }

--- a/app/Http/Controllers/API/v1/Category/CategoryController.php
+++ b/app/Http/Controllers/API/v1/Category/CategoryController.php
@@ -149,4 +149,11 @@ class CategoryController extends Controller
 
         return $this->paginate($categories->get());
     }
+
+    public function getUnpaginatedCategoryList() 
+    {
+        $categories = Category::all();
+
+        return $this->showAll($categories);
+    }
 }

--- a/app/Http/Controllers/API/v1/Quiz/QuizController.php
+++ b/app/Http/Controllers/API/v1/Quiz/QuizController.php
@@ -69,7 +69,12 @@ class QuizController extends Controller
     {
         $query = request()->query();
 
-        $quizzes = Category::join('quizzes', 'categories.id', '=', 'quizzes.category_id');
+        $quizzes = Category::join('quizzes', 'categories.id', '=', 'quizzes.category_id')
+            ->where('quizzes.title', 'LIKE', '%' . $query['search'] . '%');
+
+        if(isset($query['filter'])){
+            $quizzes->where('categories.name', $query['filter']);
+        }
 
         if(isset($query['sortDirection'])){
             return $this->sort($query, $quizzes);

--- a/routes/api.php
+++ b/routes/api.php
@@ -85,5 +85,6 @@ Route::prefix('v1')->group(function () {
         Route::patch('/admin/password-edit', [AdminController::class, 'updatePassword']);
         Route::get('/admin/users', [AdminController::class, 'getAdminAccounts']);
         Route::get('/admin/categories', [CategoryController::class, 'listOfCategories']);
+        Route::get('/admin/unpaginated-categories', [CategoryController::class, 'getUnpaginatedCategoryList']);
     });
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -85,6 +85,5 @@ Route::prefix('v1')->group(function () {
         Route::patch('/admin/password-edit', [AdminController::class, 'updatePassword']);
         Route::get('/admin/users', [AdminController::class, 'getAdminAccounts']);
         Route::get('/admin/categories', [CategoryController::class, 'listOfCategories']);
-        Route::get('/admin/unpaginated-categories', [CategoryController::class, 'getUnpaginatedCategoryList']);
     });
 });


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-301

### Definition of Done
* [x] Should filter quizzes by category
* [x] Can search quizzes by name 
* [x] Can get all quizzes without pagination 

### Related PR

FE Link: https://github.com/framgia/sph-classroom-els-fe/pull/141

### Notes
#### Main note
- API URL for quizzes: http://localhost:82/api/v1/admin_quizzes
- API URL for categories: http://localhost:82/api/v1/admin/unpaginated-categories

- Make sure to add these following query parameters when testing in Postman; 
> `search` ---> enter any quiz name to search [doesn't need to be the complete name of the quiz]
> 'filter'   ---> enter any category name [This one is case sensitive, it should be the exact name of the category]
> `sortBy` ---> can only accept these string values: Name, Category, and ID [The first letters should be capitalized, while the ID should be all caps] (Can be left blank since its not part of the task)
> `sortDirection` ----> can only accept these string values: asc or desc [should be small letters] (Can be left blank since its not part of the task)
> `page` ---> you can set this to 1 for the pagination or can be left blank as well

- Leave all query parameters blank to get the list in it's original manner.

_refer to below screenrecord_

### Screenshots
- GET THE LIST OF CATEGORIES [UNPAGINATED]
> ![UNPAGINATED CATEGORIES](https://user-images.githubusercontent.com/91049234/157624194-39dde82d-c833-4363-b3a9-a0f03ef8dc98.gif)

- SEARCH AND FILTER QUIZZES
> ![SEARCH AND FILTER QUIZZES POSTMAN](https://user-images.githubusercontent.com/91049234/157625476-387dacda-1f6c-411a-8719-0a4faea8ba48.gif)
