### PR TITLE
E_CLASSROOM-293 [Admin] [FE/BE] Categories search by name

### DIFF
--- a/app/Http/Controllers/API/v1/Category/CategoryController.php
+++ b/app/Http/Controllers/API/v1/Category/CategoryController.php
@@ -141,7 +141,8 @@ class CategoryController extends Controller
     {
         $query = request()->query();
 
-        $categories = Category::withCount('subcategories');
+        $categories = Category::withCount('subcategories')
+                                ->where('name', 'LIKE', '%' . $query['search'] . '%');
 
         if(isset($query['sortDirection'])){
             return $this->sort($query, $categories);


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-293

### Definition of Done
- [x] Search category by name
- Should use the LIKE behavior

### Commands to Run

## Related PR:
- https://github.com/framgia/sph-classroom-els-fe/pull/142
### Notes
#### Main note
- http://localhost:82/api/v1/admin/categories
- Make sure to add these following query parameters when testing in Postman;
> search ---> enter any category name to search [doesn't need to be the complete name of the category]
> listCondition ---> put if paginate or unpaginated [you can leave it black if you want to test the search]

- Leave all query parameters blank to get the list in it's original manner.
#### Pages Affected
- N/A

#### Scenarios/ Test Cases
- [x] Able to search category by name

### Screenshots
![categorysearch](https://user-images.githubusercontent.com/89514595/157818469-5967fc27-a151-40c8-abcc-9b7171135be8.PNG)
