### PR TITLE
E_CLASSROOM-337 [FE/BE] Fix change category in add/edit question

### DIFF
--- a/app/Http/Controllers/API/v1/Quiz/QuestionController.php
+++ b/app/Http/Controllers/API/v1/Quiz/QuestionController.php
@@ -76,6 +76,7 @@ class QuestionController extends Controller
      * @return \Illuminate\Http\Response
      */
 
+
     public function editQuestion(Request $request)
     {
         $questions = $request->questions;

--- a/app/Http/Controllers/API/v1/Quiz/QuestionController.php
+++ b/app/Http/Controllers/API/v1/Quiz/QuestionController.php
@@ -141,4 +141,12 @@ class QuestionController extends Controller
 
         return $this->successResponse($questions, 200);
     }
+
+    public function changeCategory($quiz_id, $category_id)
+    {
+        $quiz = Quiz::where('id', $quiz_id)->first();
+
+        $quiz->category_id = $category_id;
+        $quiz->save();
+    }
 }

--- a/app/Http/Controllers/API/v1/Quiz/QuestionController.php
+++ b/app/Http/Controllers/API/v1/Quiz/QuestionController.php
@@ -136,6 +136,7 @@ class QuestionController extends Controller
         }
 
         $this->deleteQuestions($plucked_new_question_ids, $quiz_id);
+        $this->changeCategory($quiz_id, $request->categoryId);
 
         $questions = Question::where('quiz_id', $quiz_id)->get();
 

--- a/app/Http/Controllers/API/v1/Quiz/QuestionController.php
+++ b/app/Http/Controllers/API/v1/Quiz/QuestionController.php
@@ -77,6 +77,14 @@ class QuestionController extends Controller
      */
 
 
+    public function changeCategory($quiz_id, $category_id)
+    {
+        $quiz = Quiz::where('id', $quiz_id)->first();
+
+        $quiz->category_id = $category_id;
+        $quiz->save();
+    }
+
     public function editQuestion(Request $request)
     {
         $questions = $request->questions;
@@ -137,6 +145,7 @@ class QuestionController extends Controller
         }
 
         $this->deleteQuestions($plucked_new_question_ids, $quiz_id);
+        $this->changeCategory($quiz_id, $request->categoryId);
 
         $questions = Question::where('quiz_id', $quiz_id)->get();
 

--- a/app/Http/Controllers/API/v1/Quiz/QuestionController.php
+++ b/app/Http/Controllers/API/v1/Quiz/QuestionController.php
@@ -145,9 +145,6 @@ class QuestionController extends Controller
 
     public function changeCategory($quiz_id, $category_id)
     {
-        $quiz = Quiz::where('id', $quiz_id)->first();
-
-        $quiz->category_id = $category_id;
-        $quiz->save();
+        
     }
 }

--- a/app/Http/Controllers/API/v1/Quiz/QuestionController.php
+++ b/app/Http/Controllers/API/v1/Quiz/QuestionController.php
@@ -76,15 +76,6 @@ class QuestionController extends Controller
      * @return \Illuminate\Http\Response
      */
 
-
-    public function changeCategory($quiz_id, $category_id)
-    {
-        $quiz = Quiz::where('id', $quiz_id)->first();
-
-        $quiz->category_id = $category_id;
-        $quiz->save();
-    }
-
     public function editQuestion(Request $request)
     {
         $questions = $request->questions;

--- a/app/Http/Controllers/API/v1/Quiz/QuestionController.php
+++ b/app/Http/Controllers/API/v1/Quiz/QuestionController.php
@@ -145,7 +145,6 @@ class QuestionController extends Controller
         }
 
         $this->deleteQuestions($plucked_new_question_ids, $quiz_id);
-        $this->changeCategory($quiz_id, $request->categoryId);
 
         $questions = Question::where('quiz_id', $quiz_id)->get();
 


### PR DESCRIPTION
### Issue Link
https://framgiaph.backlog.com/view/E_CLASSROOM-337

### Definition of Done
- [x] User can change category of the quiz
- [x] Add/edit question functionality is not broken

### Related Pr
fe: https://github.com/framgia/sph-classroom-els-fe/pull/152

### Commands to Run
N/A

### Notes
#### Main note
N/A
#### Pages Affected
- `http://localhost:82/api/v1/admin_edit_question'

#### Scenarios/ Test Cases
- [ ] User can change category of the quiz
- [ ] Add/edit question functionality is not broken

### Screenshots
Refer in FE Pr