### PR TITLE
E_CLASSROOM-324 [FE/BE] Display related subcategories and quizzes for the selected category

### DIFF
--- a/app/Http/Controllers/API/v1/Quiz/QuizController.php
+++ b/app/Http/Controllers/API/v1/Quiz/QuizController.php
@@ -42,6 +42,21 @@ class QuizController extends Controller
         return $this->showOne($quiz);
     }
 
+    /**
+     * Display related quizzes
+     * 
+     * @param  Category $category
+     * @return \Illuminate\Http\Response
+     */
+    public function categoryQuizzes(Request $request)
+    {
+        $categoryQuizzes = Category::join('quizzes', 'categories.id', '=', 'quizzes.category_id')
+        ->where('categories.id', $request->category_id)
+        ->get();
+
+        return $this->paginate($categoryQuizzes);
+    }
+
     public function relatedQuizzes(Request $request)
     {    
         $relatedQuizzes = Category::join('quizzes', 'categories.id', '=', 'quizzes.category_id')

--- a/routes/api.php
+++ b/routes/api.php
@@ -68,6 +68,8 @@ Route::prefix('v1')->group(function () {
         Route::get('/friendscore/{quiz_id}', [UserfriendsScoreController::class, 'friendsScore']);
         Route::get('/quiz_attempts/{quiz_id}', [UserScoresAndAttemptsController::class, 'UserScoreAndAttempts']);
         Route::post('/profileEdit', [ChangeNameEmailController::class, 'changeName']);
+        Route::post('/profileEdituploadImage', [UploadImageController::class, 'uploadAvatar']);
+        Route::get('/categories/{category_id}/categoryQuizzes', [QuizController::class, 'categoryQuizzes']);
 
         //Admin Routes
         Route::post('/admin/create', [AdminController::class, 'store']);


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-324

### Definition of Done
- [x] Able to see all related quizzes and subcategories

### Commands to Run

## Related PR:
- https://github.com/framgia/sph-classroom-els-fe/pull/153
### Notes
#### Main note
- http://localhost:82/api/v1/categories/{category_id}/categoryQuizzes
> input category_id of any category or change the category_id to the id of category
#### Pages Affected
- Student subcategory page

#### Scenarios/ Test Cases
- N/A

### Screenshots
![studentcatquiz](https://user-images.githubusercontent.com/89514595/158554833-13983c4e-2bd7-4630-b307-2a55eb282514.PNG)

