### PR TITLE
[Hotfix] Remove profile picture upload route

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -68,7 +68,6 @@ Route::prefix('v1')->group(function () {
         Route::get('/friendscore/{quiz_id}', [UserfriendsScoreController::class, 'friendsScore']);
         Route::get('/quiz_attempts/{quiz_id}', [UserScoresAndAttemptsController::class, 'UserScoreAndAttempts']);
         Route::post('/profileEdit', [ChangeNameEmailController::class, 'changeName']);
-        Route::post('/profileEdituploadImage', [UploadImageController::class, 'uploadAvatar']);
 
         //Admin Routes
         Route::post('/admin/create', [AdminController::class, 'store']);


### PR DESCRIPTION
### Issue Link

### Definition of Done
- [x] Profile picture functionality is removed
- [x] Picture display is removed
- [x] User should not be able to change profile picture
- [x] User should not be able to upload profile picture
- [x] Remove the profilePictureUpload route

#### Pages Affected
- http://localhost:3003/profile
- http://localhost:3003/admin/profile

### Scenarios/ Test Cases
- [x] Profile picture functionality is removed
- [x] Picture display is removed
- [x] User should not be able to change profile picture
- [x] User should not be able to upload profile picture
- [x] Remove the profilePictureUpload route

### Screenshots
![image](https://user-images.githubusercontent.com/26341975/158751193-eb84dd05-7374-453b-a2e5-0673c1a615a9.png)

![image](https://user-images.githubusercontent.com/26341975/158751213-909d5493-5ccf-4570-a684-e2f00bcd67e5.png)

