### PR TITLE
E_CLASSROOM-329 [FE/BE] Category Delete Function

### DIFF
--- a/app/Http/Controllers/API/v1/Category/CategoryController.php
+++ b/app/Http/Controllers/API/v1/Category/CategoryController.php
@@ -92,12 +92,13 @@ class CategoryController extends Controller
      * @param  Category  $category
      * @return \Illuminate\Http\Response
      */
-    public function destroy(Category  $category)
+    public function deleteCategory(Request $request)
     {
+        $category = Category::find($request->id);
+
         $category->delete();
 
-        return $this->showOne($category);
-    }
+        return $this->successResponse(['message' => "Successfully deleted $category->name."], 200);    }
 
     public function getCategories()
     {

--- a/routes/api.php
+++ b/routes/api.php
@@ -88,5 +88,6 @@ Route::prefix('v1')->group(function () {
         Route::get('/admin/categories', [CategoryController::class, 'listOfCategories']);
         Route::delete('/admin/delete-quiz/{quiz_id}', [QuizController::class, 'deleteQuiz']);
         Route::delete('/admin/delete-admin/{admin_id}', [AdminController::class, 'deleteAdmin']);
+        Route::delete('/admin/delete-category/{id}', [CategoryController::class, 'deleteCategory']);
     });
 });


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-329
### Definition of Done
- [x] User can delete one category/subcategory
- [x] Confirmation modal should pop-up before deleting
- [x] A modal preventing the delete will pop-up if the selected category/subcategory has child subcategory

### Commands to Run

## Related PR:
- https://github.com/framgia/sph-classroom-els-fe/pull/163
### Notes
#### Main note
- http://localhost:82/api/v1/admin/delete-category/{id}
> - Change METHOD  to DELETE
#### Pages Affected
- N/A

#### Scenarios/ Test Cases
- N/A

### Screenshots
![deletecategory](https://user-images.githubusercontent.com/89514595/159406078-8cc8d1cb-53c2-459a-8c14-25bfd1d3bd56.gif)