### PR TITLE
E_CLASSROOM-343 [Bugfix] User can input admin email in student forget password

### DIFF
--- a/app/Http/Controllers/API/v1/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/API/v1/Auth/ForgotPasswordController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\API\v1\Auth;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\ForgotPasswordRequest;
 use App\Http\Requests\Auth\ResetRequest;
+use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Hash;
@@ -17,6 +18,14 @@ class ForgotPasswordController extends Controller
 {
     public function forgotPassword(ForgotPasswordRequest $request)
     {
+        define('ADMIN_TYPE_ID', 1);
+
+        $user = User::where('email', $request->email)->first();
+
+        if($user && $user->user_type_id === ADMIN_TYPE_ID){
+            return $this->errorResponse(trans('auth.unauthorized'), 403);
+        }
+
         $status = Password::sendResetLink(
             $request->only('email')
         );

--- a/app/Http/Controllers/API/v1/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/API/v1/Auth/ForgotPasswordController.php
@@ -34,7 +34,7 @@ class ForgotPasswordController extends Controller
             return $this->authResponse('The link was sent, please Check your email');
         }
         else {
-            return $this->errorResponse("Incorrect Email", 401);
+            return $this->errorResponse(trans('auth.email'), 401);
         }
 
         throw ValidationException::withMessages([


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-343

### Definition of Done
- [x] The forgot-password route should not accept any admin emails.

### Related PR

- FE Link: 

### Notes
#### Main note
- API Route to test in POSTMAN (POST method): http://localhost:82/api/v1/forgot-password
- Required field: email

#### Scenarios/ Test Cases
- [x] The forgot-password route should not accept any admin emails.

### Screenshots
![FORGOT PASSWORD POSTMAN](https://user-images.githubusercontent.com/91049234/159624766-295347fa-9cf9-4f85-ad0a-36941e75ba29.gif)
