### PR TITLE
E_CLASSROOM-348 [Bugfix] Quiz title in /categories is not truncated

### DIFF
--- a/app/Http/Controllers/API/v1/User/UserRecentQuizzesController.php
+++ b/app/Http/Controllers/API/v1/User/UserRecentQuizzesController.php
@@ -17,7 +17,7 @@ class UserRecentQuizzesController extends Controller
         $recent = Quiz::join('quizzes_taken', 'quizzes.id', '=',  'quizzes_taken.quiz_id', )
             ->where('quizzes_taken.user_id', '=', $id)
             ->orderByDesc('quizzes_taken.created_at')
-            ->limit(4)
+            ->limit(3)
             ->get();
 
         $recentQuizzesId = $recent->unique('quiz_id')->pluck('quiz_id')->all();


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-348

### Definition of Done
- [x] When getting the user's recent quizzes, it should only return 3 data.

### Related PR

- FE Link: https://github.com/framgia/sph-classroom-els-fe/pull/177

### Notes
#### Main note
- API Route to test in POSTMAN (GET method): http://localhost:82/api/v1/recentQuizzes

#### Scenarios/ Test Cases
- [x] When getting the user's recent quizzes, it should only return 3 data.

### Screenshots
> ![RECENT QUIZZES POSTMAN](https://user-images.githubusercontent.com/91049234/159855658-99854502-ada2-43c0-8467-0ff02934071c.gif)
