### PR TITLE
E_CLASSROOM-367 [Bugfix] Update character limit for student/admin creation and update

### DIFF
--- a/app/Http/Requests/Admin/StoreAdminRequest.php
+++ b/app/Http/Requests/Admin/StoreAdminRequest.php
@@ -24,7 +24,7 @@ class StoreAdminRequest extends FormRequest
     public function rules()
     {
         return [
-            'name' => 'required|string',
+            'name' => 'required|string|max:50',
             'email' => 'required|string|unique:users,email|ends_with:sun-asterisk.com,gmail.com,yahoo.com',
         ];
     }

--- a/app/Http/Requests/Auth/ChangeNameEmailRequest.php
+++ b/app/Http/Requests/Auth/ChangeNameEmailRequest.php
@@ -25,7 +25,7 @@ class ChangeNameEmailRequest extends FormRequest
     public function rules()
     {
         return [
-            'name' => 'required|string|max:15',
+            'name' => 'required|string|max:50',
             'email' => 'required|string|ends_with:sun-asterisk.com,gmail.com,yahoo.com|unique:users,email,' . Auth::user()->id
         ];
     }

--- a/app/Http/Requests/Auth/RegisterRequest.php
+++ b/app/Http/Requests/Auth/RegisterRequest.php
@@ -25,7 +25,7 @@ class RegisterRequest extends FormRequest
     {
 
         return [
-            'name' => 'required|string',
+            'name' => 'required|string|max: 50',
             'email' => 'required|string|unique:users,email|ends_with:sun-asterisk.com,gmail.com,yahoo.com',
             'password' => 'required|string|min:6',
             'password_confirmation' => 'required|same:password',


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-367

### Definition of Done
- [x] User must be able to input maximum of 50 characters
- [x] User should not be able to input more than 50 characters

### Commands to Run


### Notes
#### Main note
- http://localhost:3003/admin/profile
- http://localhost:3003/admin/create-admin-account
- http://localhost:3003/register
- http://localhost:3003/profile/edit
#### Pages Affected
1.  Admin
- Profile edit
- Create admin account
2. Student
- Profile Edit 
- Register Page

#### Scenarios/ Test Cases
- [x] it should have a limit of 50 character
- [x] it should cannot input more than 50 character

### Screenshots
![image](https://user-images.githubusercontent.com/89514595/160337136-f6ad375e-73b2-46ff-95cb-f7a0a259aca6.png)
