### PR TITLE
E_CLASSROOM-373 [Improvement][Student] Update Recent and Follower Activities Card

### DIFF
--- a/app/Http/Controllers/API/v1/Follow/FollowController.php
+++ b/app/Http/Controllers/API/v1/Follow/FollowController.php
@@ -32,8 +32,8 @@ class FollowController extends Controller
         $logged_in_user = activity()
         ->causedBy($logged_in_user)
         ->performedOn($to_follow_user)
-        ->withProperties(['name' => $name, 'email' => $email, 'user_type_id' => $user_type_id])
-        ->log(' :properties.name followed :subject.name');
+        ->withProperties(['name' => $name, 'followed_id' => $to_follow_user->id, 'followed_name' => $to_follow_user->name])
+        ->log(':properties.name followed :subject.name');
 
         return $this->successResponse("Successfully followed student", 200);
     }
@@ -57,8 +57,8 @@ class FollowController extends Controller
         $logged_in_user = activity()
         ->causedBy($logged_in_user)
         ->performedOn($to_unfollow_user)
-        ->withProperties(['name' => $name, 'email' => $email, 'user_type_id' => $user_type_id])
-        ->log(' :properties.name unfollowed :subject.name');
+        ->withProperties(['name' => $name, 'unfollowed_id' => $to_unfollow_user->id, 'unfollowed_name' => $to_unfollow_user->name])
+        ->log(':properties.name unfollowed :subject.name');
 
 
         return $this->successResponse("Successfully unfollowed student", 200);

--- a/app/Http/Controllers/API/v1/Quiz/QuizzesTakenController.php
+++ b/app/Http/Controllers/API/v1/Quiz/QuizzesTakenController.php
@@ -140,4 +140,13 @@ class QuizzesTakenController extends Controller
 
         return $this->showAll($categories_with_quizzestaken_only); 
     }
+
+    public function getTakenQuizScore(Request $request)
+    {
+        $score = DB::table('quizzes_taken')
+                          ->where('id', $request->quiz_taken_id)
+                          ->get('score');
+
+        return $this->successResponse($score, 200);
+    }
 }

--- a/app/Http/Controllers/API/v1/Quiz/QuizzesTakenController.php
+++ b/app/Http/Controllers/API/v1/Quiz/QuizzesTakenController.php
@@ -58,8 +58,13 @@ class QuizzesTakenController extends Controller
         $activityquiz = activity()
         ->causedBy($logged_in_user)
         ->performedOn($quiz)
-        ->withProperties(['name' => $name, 'email' => $email, 'user_type_id' => $user_type_id])
-        ->log(' :properties.name Answered :subject.title Quiz');
+        ->withProperties([
+            'name' => $name, 
+            'taken_quiz' => $quiztaken,
+            'quiz' => $quiz, 
+            'questions' => $quiz->questions,
+            'category_id' => $quiz->category_id
+        ])->log(':properties.name answered :subject.title');
 
         return $this->successResponse(['quizzes_taken_id' => $quizzes_taken_id], 200);
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -52,6 +52,7 @@ Route::prefix('v1')->group(function () {
         Route::resource('/quizzes.questions', QuestionController::class);
         Route::resource('/quizzes-taken', QuizzesTakenController::class);
         Route::resource('/quizzes-taken.answers', QuizAnswerController::class);
+        Route::get('/quizzes-taken/{quiz_taken_id}/score', [QuizzesTakenController::class, 'getTakenQuizScore']);
         Route::post('/change-password', [ChangePasswordController::class, 'changePassword']);
         Route::get('/learnings', [LearningsController::class, 'show']);
 


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-373

### Definition of Done
* [x] Text in the recent activities should be truncated
* [x] If the user hovers over the text, the full text should be seen in a tooltip
* [x] Each Recent Activity should link to the results page for the specific quiz
* [x] Each Follower Activity should link to the profile page of the user
* [x] Update the text in the Recent Activity to 'You answered .....' (remove the quiz and update the 'answered' word

### Related PR

- FE Link: https://github.com/framgia/sph-classroom-els-fe/pull/200

### Notes
### Scenarios/ Test Cases
* [x] Text in the recent activities should be truncated
* [x] If the user hovers over the text, the full text should be seen in a tooltip
* [x] Each Recent Activity should link to the results page for the specific quiz
* [x] Each Follower Activity should link to the profile page of the user
* [x] Update the text in the Recent Activity to 'You answered .....' (remove the quiz and update the 'answered' word

### Screenshots
DASHBOARD:
> ![image](https://user-images.githubusercontent.com/91049234/160769935-507534f7-444a-4427-a449-531ed8bac7da.png)

STUDENT PROFILE:
> ![image](https://user-images.githubusercontent.com/91049234/160769133-b67d57af-eca9-44ed-ab55-62a54b85a699.png)

USER PROFILE
> ![USER PROFILE](https://user-images.githubusercontent.com/91049234/160769898-007dbbc0-a59c-48aa-8adf-4516a38a9020.gif)
