### PR TITLE
E_CLASSROOM-385 [Bugfix] Blank space is rendered if related quiz has no questions

### DIFF
--- a/app/Http/Controllers/API/v1/Quiz/QuizController.php
+++ b/app/Http/Controllers/API/v1/Quiz/QuizController.php
@@ -45,14 +45,13 @@ class QuizController extends Controller
     }
 
     public function relatedQuizzes(Request $request)
-    {    
-        $relatedQuizzes = Quiz::join('categories', 'quizzes.category_id', '=', 'categories.id')
-            ->has('questions')
+    {   
+        $relatedQuizzes  = Quiz::has('questions')
+            ->where('quizzes.category_id', $request->category_id)
             ->where('quizzes.id', '!=', $request->quiz_id )
-            ->where('categories.id', $request->category_id)
             ->limit(4)
             ->get();
-    
+
         $relatedQuizzesId = $relatedQuizzes->pluck('quiz_id')->all();
 
         $attempts = QuizTaken::whereIn('quiz_id', $relatedQuizzesId)

--- a/app/Http/Controllers/API/v1/Quiz/QuizController.php
+++ b/app/Http/Controllers/API/v1/Quiz/QuizController.php
@@ -46,12 +46,13 @@ class QuizController extends Controller
 
     public function relatedQuizzes(Request $request)
     {    
-        $relatedQuizzes = Category::join('quizzes', 'categories.id', '=', 'quizzes.category_id')
-            ->where('categories.id', $request->category_id)
+        $relatedQuizzes = Quiz::join('categories', 'quizzes.category_id', '=', 'categories.id')
+            ->has('questions')
             ->where('quizzes.id', '!=', $request->quiz_id )
+            ->where('categories.id', $request->category_id)
             ->limit(4)
             ->get();
-        
+    
         $relatedQuizzesId = $relatedQuizzes->pluck('quiz_id')->all();
 
         $attempts = QuizTaken::whereIn('quiz_id', $relatedQuizzesId)


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-385

### Definition of Done
- [x] Get data that have a question

### Commands to Run

## Related PR:
- https://github.com/framgia/sph-classroom-els-fe/pull/205
### Notes
#### Main note
- http://localhost:82/api/v1/categories/{category_id}/relatedQuizzes/{quiz_id}
#### Pages Affected
- Student Result page

#### Scenarios/ Test Cases
- [x] it should get data that have questions

### Screenshots
![image](https://user-images.githubusercontent.com/89514595/160805341-33fdffd6-bc22-4ede-b30d-c1ef5d168a25.png)
