### PR TITLE
E_CLASSROOM-384 [Improvement][Student] Implement sort in /learnings t…

### DIFF
--- a/app/Http/Controllers/API/v1/Learn/LearningsController.php
+++ b/app/Http/Controllers/API/v1/Learn/LearningsController.php
@@ -8,24 +8,26 @@ use App\Models\Category;
 use App\Models\Quiz;
 use App\Models\QuizTaken;
 use App\Traits\Pagination;
+use App\Traits\LearningsSort;
 
 class LearningsController extends Controller
 {
-    use Pagination;
+    use Pagination, LearningsSort;
 
     public function show(Request $request)
     {
         $id = Auth::user()->id;
+        $query = request()->query();
         
-        $quizzes_taken_by_user = Quiz::join('quizzes_taken','quizzes.id', '=', 'quizzes_taken.quiz_id')
+        $quizzes_learned = Quiz::join('quizzes_taken','quizzes.id', '=', 'quizzes_taken.quiz_id')
                                 ->join('categories', 'quizzes.category_id', '=', 'categories.id')
                                 ->where('quizzes_taken.user_id', $id)
-                                ->orderByDesc('quizzes_taken.created_at')
-                                ->with('questions')
-                                ->get()
-                                ->unique('quiz_id')
-                                ->values();
-
-        return $this->paginate($quizzes_taken_by_user);
+                                ->with('questions');
+                            
+        if(isset($query['sortDirection'])){
+            $this->sort($query, $quizzes_learned);
+        } 
+           
+        return $this->paginate($quizzes_learned->get()->unique('quiz_id')->values());
     }
 }

--- a/app/Traits/LearningsSort.php
+++ b/app/Traits/LearningsSort.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Facades\Auth;
+use App\Traits\Pagination;
+
+trait LearningsSort
+{
+    protected function sort($query, $learnings)
+    {
+        switch($query['sortBy']){
+            case 'Quizzes Learned': 
+                $sortBy = 'quizzes.title';
+                break;
+            case 'Categories':
+                $sortBy = 'categories.name';
+                break;
+        }
+        
+        $learnings->orderBy($sortBy, $query['sortDirection']);
+
+        return $this->paginate($learnings->get()->unique('quiz_id')->values());
+    }
+}


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-384

### Definition of Done
- [x] User should be able to sort by quiz name
- [x] User should be able to sort by category
- [x] The sort functionality of this page should have the same behavior as the one on the admin side.

### Related PR

FE Link: https://github.com/framgia/sph-classroom-els-fe/pull/210

### Notes
### Scenarios/ Test Cases
- [x] User should be able to sort by quiz name
- [x] User should be able to sort by category
- [x] The sort functionality of this page should have the same behavior as the one on the admin side.

### Screenshots
![SORT LEARNINGS](https://user-images.githubusercontent.com/91049234/160972682-8f0d8080-ed71-4185-bf7b-cb2ce1c49026.gif)
