### PR TITLE
E_CLASSROOM-380 [Improvement][Admin] Edit quiz name and UI fix

### DIFF
--- a/app/Http/Controllers/API/v1/Quiz/QuestionController.php
+++ b/app/Http/Controllers/API/v1/Quiz/QuestionController.php
@@ -136,17 +136,18 @@ class QuestionController extends Controller
         }
 
         $this->deleteQuestions($plucked_new_question_ids, $quiz_id);
-        $this->changeCategory($quiz_id, $request->categoryId);
+        $this->changeQuizInfo($quiz_id, $request->categoryId, $request->quizTitle);
 
         $questions = Question::where('quiz_id', $quiz_id)->get();
 
         return $this->successResponse($questions, 200);
     }
 
-    public function changeCategory($quiz_id, $category_id)
+    public function changeQuizInfo($quiz_id, $category_id, $quizTitle)
     {
         $quiz = Quiz::find($quiz_id);
 
+        $quiz->title = $quizTitle;
         $quiz->category_id = $category_id;
         $quiz->save();
     }


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-380

### Definition of Done
* [x] Quiz title on the quiz edit page should be displayed in an input form so that the user can edit the quiz title.
* [x] Button width is aligned with the question boxes
* [x] If the user is in the quiz child routes, the 'Quizzes' in the sidebar should be highlighted

### Related PR

- FE Link: https://github.com/framgia/sph-classroom-els-fe/pull/211

### Notes
#### Scenarios/ Test Cases
* [x] Quiz title on the quiz edit page should be displayed in an input form so that the user can edit the quiz title.
* [x] Button width is aligned with the question boxes
* [x] If the user is in the quiz child routes, the 'Quizzes' in the sidebar should be highlighted

### Screenshots
![EDIT QUIZ](https://user-images.githubusercontent.com/91049234/160988789-e65d91cb-c9bc-4189-9c88-75ca86341167.gif)
